### PR TITLE
Add s3 copy for snapshot release

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -27,8 +27,6 @@ jobs:
                 aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                 aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                 aws-region: eu-west-3
-            # - name: Pull existing releases artifacts from S3
-            #   run: aws s3 cp --recursive s3://fork-test/my-sandbox/releases ./releases
             - name: Extract snapshot name
               id: extract_snapshot_name
               run: |

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -21,6 +21,14 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
             - name: Install dependencies
               run: yarn
+            - name: Configure AWS Credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                aws-region: eu-west-3
+            # - name: Pull existing releases artifacts from S3
+            #   run: aws s3 cp --recursive s3://fork-test/my-sandbox/releases ./releases
             - name: Extract snapshot name
               id: extract_snapshot_name
               run: |
@@ -31,3 +39,5 @@ jobs:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
               run: yarn create-snapshot-release ${{ steps.extract_snapshot_name.outputs.snapshot-name }}
+            - name: Copy releases artifacts to S3
+              run: aws s3 cp --recursive ./releases s3://fork-test/my-sandbox/releases

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ From the [Changesets documentation](https://github.com/changesets/changesets/blo
 > Snapshot releases are a way to release your changes for testing without updating the versions. Both a modified `version` and a modified `publish` command are used to do accomplish a snapshot release. After both processes run, you will have a published version of packages in changesets with a version of `0.0.0-{tag}-DATETIMESTAMP`.
 
 In order to publish a snapshot release, one first creates a branch `snapshot/<snapshot name>` with the target smart contract codebase. Once the branch is created,
-- **If the user has the authorization to publish the NPM package**, he/she can run `yarn snapshot-release <snapshot-name>`. At this point, the branch can be deleted,
-- **Otherwise**, the user can push the branch, even if there are no changes, to the remote registry, i.e. `git push`. If the branch was correctly named, it will trigger a workflow in order to create the snapshot release. Once the release has been successful, the branch can be deleted.
+- **Recommended option**, the user can push the branch, even if there are no changes, to the remote registry, i.e. `git push`. If the branch was correctly named, it will trigger a workflow in order to create the snapshot release. Once the release has been successful, the branch can be deleted,
+- **If the user has the authorization to publish the NPM package**, he/she can run `yarn snapshot-release <snapshot-name>` and then copy the artifacts to the S3. At this point, the branch can be deleted.
 
 
 ## About deployment


### PR DESCRIPTION
## Summary

Copy of artifacts to s3 is made for snapshot releases