### PR TITLE
use path instead of string concatenation

### DIFF
--- a/scripts/constants.ts
+++ b/scripts/constants.ts
@@ -1,0 +1,28 @@
+import path from "node:path";
+
+// Releases folder
+export const RELEASES_FOLDER = path.join(__dirname, "../../releases");
+// Generated delta releases folder
+export const GENERATED_DELTA_FOLDER = path.join(
+  RELEASES_FOLDER,
+  "generated-delta",
+);
+export const GENERATED_DELTA_CONTRACTS_ARTIFACTS_FOLDER = path.join(
+  GENERATED_DELTA_FOLDER,
+  "contracts",
+);
+export const GENERATED_DELTA_BUILD_INFOS_ARTIFACTS_FOLDER = path.join(
+  GENERATED_DELTA_FOLDER,
+  "build-infos",
+);
+// Snapshots releases folder
+export const SNAPSHOTS_RELEASES_FOLDER = path.join(
+  RELEASES_FOLDER,
+  "snapshots",
+);
+
+// Final `dist` folder of bundled artifacts
+export const DIST_FOLDER = path.join(__dirname, "../../dist");
+
+// Tmp folder used by the hardhat compilation
+export const RELEASES_TMP_FOLDER = path.join(RELEASES_FOLDER, "tmp");

--- a/scripts/copy-dist.ts
+++ b/scripts/copy-dist.ts
@@ -1,25 +1,32 @@
 import fs from "fs/promises";
 import { toResult } from "./utils";
+import path from "node:path";
+import { DIST_FOLDER } from "./constants";
+
+// Exposed `abis` folder
+const ABIS_FOLDER = path.join(__dirname, "../../abis");
 
 async function copyDistToAbis() {
   // Check that `dist` folder exists
-  const hasDistFolder = await fs.stat("./dist").catch(() => false);
+  const hasDistFolder = await fs.stat(DIST_FOLDER).catch(() => false);
   if (!hasDistFolder) {
     // Exit if there are no dist folder
     console.error(
-      "❌ Dist folder has not been found at `./dist`. It should have been previously created by the hardhat compilation.",
+      `❌ Dist folder has not been found at \`${DIST_FOLDER}\`. It should have been previously created by the hardhat compilation.`,
     );
     process.exitCode = 1;
     return;
   }
 
   // Remove `abis` folder if it exists
-  const hasAbisFolder = await fs.stat("./abis").catch(() => false);
+  const hasAbisFolder = await fs.stat(ABIS_FOLDER).catch(() => false);
   if (hasAbisFolder) {
-    const removeResult = await toResult(fs.rm("./abis", { recursive: true }));
+    const removeResult = await toResult(
+      fs.rm(ABIS_FOLDER, { recursive: true }),
+    );
     if (!removeResult.ok) {
       console.error(
-        "❌ An error occurred while removing the `./abis` folder.",
+        `❌ An error occurred while removing the \`${ABIS_FOLDER}\` folder.`,
         removeResult.error,
       );
       process.exitCode = 1;
@@ -28,10 +35,10 @@ async function copyDistToAbis() {
   }
 
   // Create `abis` folder
-  const mkdirResult = await toResult(fs.mkdir("./abis"));
+  const mkdirResult = await toResult(fs.mkdir(ABIS_FOLDER));
   if (!mkdirResult.ok) {
     console.error(
-      "❌ An error occurred while creating the `./abis` folder.",
+      `❌ An error occurred while creating the \`${ABIS_FOLDER}\` folder.`,
       mkdirResult.error,
     );
     process.exitCode = 1;
@@ -40,18 +47,20 @@ async function copyDistToAbis() {
 
   // Copy `dist` folder content into `abis` folder
   const copyResult = await toResult(
-    fs.cp("./dist", "./abis", { recursive: true }),
+    fs.cp(DIST_FOLDER, ABIS_FOLDER, { recursive: true }),
   );
   if (!copyResult.ok) {
     console.error(
-      "❌ An error occurred while copying the `./dist` folder into `./abis`.",
+      `❌ An error occurred while copying the \`${DIST_FOLDER}\` folder into \`${ABIS_FOLDER}\`.`,
       copyResult.error,
     );
     process.exitCode = 1;
     return;
   }
 
-  console.log("\n✅ Successfully copied `./dist` into `./abis` for release.\n");
+  console.log(
+    `\n✅ Successfully copied \`${DIST_FOLDER}\` into \`${ABIS_FOLDER}\` for release.\n`,
+  );
 }
 
 copyDistToAbis();


### PR DESCRIPTION
## Summary

`path` from `node:path` is used instead of string concatenation