### PR TITLE
create releases workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
-    name: Release
+    name: Release latest
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,9 +1,8 @@
-name: Tags workflow
+name: Releases workflow
 
 on:
-  push:
-    tags:
-      - "**"
+  release:
+    types: [published]
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ For now, the process is to have:
   - stored in `releases/latest/build-info.json`,
   - updated on push on `main` branch.
 - as many as we want other releases:
-  - stored in `releases/<release name>/build-info.json` in `main` branch,
+  - stored in `releases/<release name>/build-info.json` in the release branch,
   - created on releases.
 
 The associated workflows have been made:
 
 - pr.yml: compile the artifacts, create a diff with the artifacts in `latest` release and publish a comment on the PR of the list of differences,
 - main.yml: compile the artifacts, copy them in `releases/latest` and commit the changes in `main` branch,
-- releases.yml: compile the artifacts, copy them in `releases/<tag name>` and commit the changes in `main` branch.
+- releases.yml: compile the artifacts, copy them in `releases/<tag name>` and commit the changes in the release branch.
 
 ## What needs to be done
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ For now, the process is to have:
   - stored in `releases/latest/build-info.json`,
   - updated on push on `main` branch.
 - as many as we want other releases:
-  - stored in `releases/<release name>/build-info.json`,
-  - created on push on `tags`, e.g. `v2.1.2`.
+  - stored in `releases/<release name>/build-info.json` in `main` branch,
+  - created on releases.
 
 The associated workflows have been made:
 
 - pr.yml: compile the artifacts, create a diff with the artifacts in `latest` release and publish a comment on the PR of the list of differences,
-- main.yml: compile the artifacts, copy them in `releases/latest` and commit the changes,
-- tags.yml: compile the artifacts, copy them in `releases/<tag name>` and commit the changes.
+- main.yml: compile the artifacts, copy them in `releases/latest` and commit the changes in `main` branch,
+- releases.yml: compile the artifacts, copy them in `releases/<tag name>` and commit the changes in `main` branch.
 
 ## What needs to be done
 


### PR DESCRIPTION
## Summary

Remove the tags workflow, it was never going to work as intended.

Create instead the `releases` workflow to create the associated release artifacts in the release branch when creating a release.