### PR TITLE
fix release build

### DIFF
--- a/.github/release.sh
+++ b/.github/release.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 RELEASE_TAG_WITHOUT_PREFIX=$(cat package.json | jq -r '.version')
 

--- a/scripts/build-exposed-abis.ts
+++ b/scripts/build-exposed-abis.ts
@@ -231,7 +231,10 @@ async function fillAbisTmpFolder() {
     .filter((name) => name !== "generated");
 
   for (const release of releasesDirectories) {
-    const buildInfoResult = await toAsyncResult(getReleaseBuildInfo(release));
+    const buildInfoResult = await toAsyncResult(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getReleaseBuildInfo(release as any),
+    );
     if (!buildInfoResult.success) {
       throw buildInfoResult.error;
     }


### PR DESCRIPTION
## Summary

- The `release` script will automatically fail if one of the subcommand fails,
- The `release` typing is cast as `any` for the building of the ABIs as it is a helper script